### PR TITLE
Streaming macro

### DIFF
--- a/sPHENIX/cosmics/Fun4All_Stream_Combiner.C
+++ b/sPHENIX/cosmics/Fun4All_Stream_Combiner.C
@@ -16,9 +16,16 @@
 #include <ffarawmodules/StreamingCheck.h>
 #include <ffarawmodules/TpcCheck.h>
 
+#include <ffamodules/HeadReco.h>
+#include <ffamodules/FlagHandler.h>
+#include <ffamodules/SyncReco.h>
+
 R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libffamodules.so)
 R__LOAD_LIBRARY(libfun4allraw.so)
 R__LOAD_LIBRARY(libffarawmodules.so)
+
+bool isGood(const string &infile);
 
 void Fun4All_Stream_Combiner(int nEvents = 100,
 			     int runnumber = 30117,
@@ -67,121 +74,59 @@ void Fun4All_Stream_Combiner(int nEvents = 100,
                              const string &input_tpotfile = "tpot.list"
 )
 {
-  vector<string> infile_tmp;
 // GL1 which provides the beam clock reference (if we ran with GL1)
   vector<string> gl1_infile;
-  ifstream intest(input_gl1file);
-  if (intest.is_open()) // does it exist?
-  {
-    if (intest.peek() != std::ifstream::traits_type::eof()) // is it non zero?
-    {
-      gl1_infile.push_back(input_gl1file);
-    }
-    intest.close();
-  }
-// TPOT
-  vector<string> tpot_infile;
-  intest.open(input_tpotfile);
-  if (intest.is_open()) // does it exist?
-  {
-    if (intest.peek() != std::ifstream::traits_type::eof()) // is it non zero?
-    {
-      tpot_infile.push_back(input_tpotfile);
-    }
-    intest.close();
-  }
-// INTT
-  vector<string> intt_infile;
-  infile_tmp.push_back(input_inttfile00);
-  infile_tmp.push_back(input_inttfile01);
-  infile_tmp.push_back(input_inttfile02);
-  infile_tmp.push_back(input_inttfile03);
-  infile_tmp.push_back(input_inttfile04);
-  infile_tmp.push_back(input_inttfile05);
-  infile_tmp.push_back(input_inttfile06);
-  infile_tmp.push_back(input_inttfile07);
-  for (int i=0; i<infile_tmp.size(); i++)
-  {
-// C++ std17 filesystem::exists does not work in our CLING version
-//    std::cout << infile_tmp[i] << std::endl;
-    intest.open(infile_tmp[i]);
-    if (intest.is_open()) // does it exist?
-    {
-      if (intest.peek() != std::ifstream::traits_type::eof()) // is it non zero?
-      {
-	intt_infile.push_back(infile_tmp[i]);
-      }
-      intest.close();
-    }
-  }
-  infile_tmp.clear();
+  gl1_infile.push_back(input_gl1file);
 
 // MVTX
   vector<string> mvtx_infile;
-  infile_tmp.push_back(input_mvtxfile00);
-  infile_tmp.push_back(input_mvtxfile01);
-  infile_tmp.push_back(input_mvtxfile02);
-  infile_tmp.push_back(input_mvtxfile03);
-  infile_tmp.push_back(input_mvtxfile04);
-  infile_tmp.push_back(input_mvtxfile05);
-  for (int i=0; i<infile_tmp.size(); i++)
-  {
-// C++ std17 filesystem::exists does not work in our CLING version
-//    std::cout << infile_tmp[i] << std::endl;
-    intest.open(infile_tmp[i]);
-    if (intest.is_open()) // does it exist?
-    {
-      if (intest.peek() != std::ifstream::traits_type::eof()) // is it non zero?
-      {
-	mvtx_infile.push_back(infile_tmp[i]);
-      }
-      intest.close();
-    }
-  }
-  infile_tmp.clear();
+  mvtx_infile.push_back(input_mvtxfile00);
+  mvtx_infile.push_back(input_mvtxfile01);
+  mvtx_infile.push_back(input_mvtxfile02);
+  mvtx_infile.push_back(input_mvtxfile03);
+  mvtx_infile.push_back(input_mvtxfile04);
+  mvtx_infile.push_back(input_mvtxfile05);
 
+// INTT
+  vector<string> intt_infile;
+  intt_infile.push_back(input_inttfile00);
+  intt_infile.push_back(input_inttfile01);
+  intt_infile.push_back(input_inttfile02);
+  intt_infile.push_back(input_inttfile03);
+  intt_infile.push_back(input_inttfile04);
+  intt_infile.push_back(input_inttfile05);
+  intt_infile.push_back(input_inttfile06);
+  intt_infile.push_back(input_inttfile07);
 
   vector<string> tpc_infile;
-  infile_tmp.push_back(input_tpcfile00);
-  infile_tmp.push_back(input_tpcfile01);
-  infile_tmp.push_back(input_tpcfile02);
-  infile_tmp.push_back(input_tpcfile03);
-  infile_tmp.push_back(input_tpcfile04);
-  infile_tmp.push_back(input_tpcfile05);
-  infile_tmp.push_back(input_tpcfile06);
-  infile_tmp.push_back(input_tpcfile07);
-  infile_tmp.push_back(input_tpcfile08);
-  infile_tmp.push_back(input_tpcfile09);
-  infile_tmp.push_back(input_tpcfile10);
-  infile_tmp.push_back(input_tpcfile11);
-  infile_tmp.push_back(input_tpcfile12);
-  infile_tmp.push_back(input_tpcfile13);
-  infile_tmp.push_back(input_tpcfile14);
-  infile_tmp.push_back(input_tpcfile15);
-  infile_tmp.push_back(input_tpcfile16);
-  infile_tmp.push_back(input_tpcfile17);
-  infile_tmp.push_back(input_tpcfile18);
-  infile_tmp.push_back(input_tpcfile19);
-  infile_tmp.push_back(input_tpcfile20);
-  infile_tmp.push_back(input_tpcfile21);
-  infile_tmp.push_back(input_tpcfile22);
-  infile_tmp.push_back(input_tpcfile23);
+  tpc_infile.push_back(input_tpcfile00);
+  tpc_infile.push_back(input_tpcfile01);
+  tpc_infile.push_back(input_tpcfile02);
+  tpc_infile.push_back(input_tpcfile03);
+  tpc_infile.push_back(input_tpcfile04);
+  tpc_infile.push_back(input_tpcfile05);
+  tpc_infile.push_back(input_tpcfile06);
+  tpc_infile.push_back(input_tpcfile07);
+  tpc_infile.push_back(input_tpcfile08);
+  tpc_infile.push_back(input_tpcfile09);
+  tpc_infile.push_back(input_tpcfile10);
+  tpc_infile.push_back(input_tpcfile11);
+  tpc_infile.push_back(input_tpcfile12);
+  tpc_infile.push_back(input_tpcfile13);
+  tpc_infile.push_back(input_tpcfile14);
+  tpc_infile.push_back(input_tpcfile15);
+  tpc_infile.push_back(input_tpcfile16);
+  tpc_infile.push_back(input_tpcfile17);
+  tpc_infile.push_back(input_tpcfile18);
+  tpc_infile.push_back(input_tpcfile19);
+  tpc_infile.push_back(input_tpcfile20);
+  tpc_infile.push_back(input_tpcfile21);
+  tpc_infile.push_back(input_tpcfile22);
+  tpc_infile.push_back(input_tpcfile23);
 
-  for (int i=0; i<infile_tmp.size(); i++)
-  {
-// C++ std17 filesystem::exists does not work in our CLING version
-//    std::cout << infile_tmp[i] << std::endl;
-    intest.open(infile_tmp[i]);
-    if (intest.is_open()) // does it exist?
-    {
-      if (intest.peek() != std::ifstream::traits_type::eof()) // is it non zero?
-      {
-	tpc_infile.push_back(infile_tmp[i]);
-      }
-      intest.close();
-    }
-  }
-  infile_tmp.clear();
+// TPOT
+  vector<string> tpot_infile;
+  tpot_infile.push_back(input_tpotfile);
 
   Fun4AllServer *se = Fun4AllServer::instance();
   se->Verbosity(1);
@@ -189,19 +134,27 @@ void Fun4All_Stream_Combiner(int nEvents = 100,
   // rc->set_IntFlag("RUNNUMBER",20445);
   Fun4AllStreamingInputManager *in = new Fun4AllStreamingInputManager("Comb");
   //  in->Verbosity(2);
+// create and register input managers
   int i = 0;
+
   for (auto iter : gl1_infile)
   {
-    SingleGl1PoolInput *gl1_sngl = new SingleGl1PoolInput("GL1_" + to_string(i));
-    //    gl1_sngl->Verbosity(3);
-    gl1_sngl->AddListFile(iter);
-    in->registerStreamingInput(gl1_sngl, InputManagerType::GL1);
-    i++;
+    if (isGood(iter))
+    {
+      SingleGl1PoolInput *gl1_sngl = new SingleGl1PoolInput("GL1_" + to_string(i));
+      //    gl1_sngl->Verbosity(3);
+      gl1_sngl->AddListFile(iter);
+      in->registerStreamingInput(gl1_sngl, InputManagerType::GL1);
+      i++;
+    }
   }
-
   i = 0;
+
+
   for (auto iter : intt_infile)
   {
+    if (isGood(iter))
+    {
     SingleInttPoolInput *intt_sngl = new SingleInttPoolInput("INTT_" + to_string(i));
     //    intt_sngl->Verbosity(3);
     intt_sngl->SetNegativeBco(1);
@@ -209,9 +162,13 @@ void Fun4All_Stream_Combiner(int nEvents = 100,
     intt_sngl->AddListFile(iter);
     in->registerStreamingInput(intt_sngl, InputManagerType::INTT);
     i++;
+    }
   }
-   for (auto iter : mvtx_infile)
+  i = 0;
+  for (auto iter : mvtx_infile)
   {
+    if (isGood(iter))
+    {
     SingleMvtxPoolInput *mvtx_sngl = new SingleMvtxPoolInput("MVTX_" + to_string(i));
     //    mvtx_sngl->Verbosity(3);
     mvtx_sngl->SetBcoRange(1000);
@@ -219,20 +176,28 @@ void Fun4All_Stream_Combiner(int nEvents = 100,
     mvtx_sngl->AddListFile(iter);
     in->registerStreamingInput(mvtx_sngl, InputManagerType::MVTX);
     i++;
+    }
   }
   i = 0;
   for (auto iter : tpc_infile)
   {
+    if (isGood(iter))
+    {
     SingleTpcPoolInput *tpc_sngl = new SingleTpcPoolInput("TPC_" + to_string(i));
-    //    tpc_sngl->Verbosity(3);
+//    tpc_sngl->Verbosity(2);
+    //   tpc_sngl->DryRun();
     tpc_sngl->SetBcoRange(130);
     tpc_sngl->AddListFile(iter);
     in->registerStreamingInput(tpc_sngl, InputManagerType::TPC);
     i++;
+    }
   }
   i = 0;
+
   for (auto iter : tpot_infile)
   {
+    if (isGood(iter))
+    {
     SingleMicromegasPoolInput *mm_sngl = new SingleMicromegasPoolInput("MICROMEGAS_" + to_string(i));
     //   sngl->Verbosity(3);
     mm_sngl->SetBcoRange(100);
@@ -240,6 +205,7 @@ void Fun4All_Stream_Combiner(int nEvents = 100,
     mm_sngl->AddListFile(iter);
     in->registerStreamingInput(mm_sngl, InputManagerType::MICROMEGAS);
     i++;
+    }
   }
 
   se->registerInputManager(in);
@@ -250,6 +216,15 @@ void Fun4All_Stream_Combiner(int nEvents = 100,
   // tpccheck->Verbosity(3);
   // tpccheck->SetBcoRange(130);
   // se->registerSubsystem(tpccheck);
+
+  SyncReco *sync = new SyncReco();
+  se->registerSubsystem(sync);
+
+  HeadReco *head = new HeadReco();
+  se->registerSubsystem(head);
+
+  FlagHandler *flag = new FlagHandler();
+  se->registerSubsystem(flag);
 
   string outfilename = "./" + type + ".root";
   Fun4AllOutputManager *out = new Fun4AllDstOutputManager("out",outfilename);
@@ -269,4 +244,20 @@ void Fun4All_Stream_Combiner(int nEvents = 100,
   delete se;
   cout << "all done" << endl;
   gSystem->Exit(0);
+}
+
+bool isGood(const string &infile)
+{
+  ifstream intest;
+  intest.open(infile);
+  bool goodfile = false;
+  if (intest.is_open())
+  {
+    if (intest.peek() != std::ifstream::traits_type::eof()) // is it non zero?
+    {
+      goodfile = true;
+    }
+      intest.close();
+  }
+  return goodfile;
 }

--- a/sPHENIX/cosmics/GetEntries.C
+++ b/sPHENIX/cosmics/GetEntries.C
@@ -4,8 +4,8 @@
 R__LOAD_LIBRARY(libFROG.so)
 void GetEntries(const std::string &file)
 {
-  gSystem->Load("libFROG.so");                                                                                                                                                                                                                                                                                                                                  
-  gSystem->Load("libg4dst.so");                                                                                                                                                                                                                                                                                                                                 
+  gSystem->Load("libFROG.so");
+  gSystem->Load("libg4dst.so");
   // prevent root to start gdb-backtrace.sh
   // in case of crashes, it hangs the condor job
   for (int i = 0; i < kMAXSIGNALS; i++)
@@ -16,6 +16,11 @@ void GetEntries(const std::string &file)
   TFile *f = TFile::Open(fr->location(file));
   cout << "Getting events for " << file << endl;
   TTree *T = (TTree *) f->Get("T");
-  cout << "Number of Entries: " <<  T->GetEntries() << endl;                                                                                                                                                                                                                                                                                                    
+  int nEntries = -1
+  if (T)
+  {
+    nEntries = T->GetEntries();
+  }
+  cout << "Number of Entries: " <<  nEntries << endl;
 };              
 #endif


### PR DESCRIPTION
This PR simplifies the Streaming macro and add important modules which create the run and event header, the synchronization object and the storage for the flags. This needs the latest build.
Gave the GetEntries macro a shot to catch the condition if the T - TTree is not found in the file. It returns -1 as number of entries in this case