### PR TITLE
fix: strip mvtx evt header

### DIFF
--- a/sPHENIX/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
+++ b/sPHENIX/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
@@ -69,6 +69,8 @@ void Fun4All_TrkrHitSet_Unpacker(
   out->StripNode("MICROMEGASRAWHIT");
   out->StripNode("TPCRAWHIT");
   out->StripNode("GL1RAWHIT");
+  out->StripNode("MVTXRAWEVTHEADER");
+  out->StripNode("MVTXEVENTHEADER");
 
   se->registerOutputManager(out);
 


### PR DESCRIPTION
Strips out MVTX event header nodes which are not needed after unpacking hits.