### PR TITLE
Fix sync

### DIFF
--- a/sPHENIX/CaloProduction/Fun4All_HCalCosmics.C
+++ b/sPHENIX/CaloProduction/Fun4All_HCalCosmics.C
@@ -9,7 +9,6 @@
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <ffamodules/HeadReco.h>
-#include <ffamodules/SyncReco.h>
 
 #include <fun4allraw/Fun4AllPrdfInputManager.h>
 
@@ -80,13 +79,6 @@ void Fun4All_HCalCosmics(int nEvents = 0,
   // // 64 bit timestamp
   rc->set_uint64Flag("TIMESTAMP", runnumber);
   CDBInterface::instance()->Verbosity(1);
-
-  // Sync Headers and Flags
-  SyncReco *sync = new SyncReco();
-  se->registerSubsystem(sync);
-
-  HeadReco *head = new HeadReco();
-  se->registerSubsystem(head);
 
   FlagHandler *flag = new FlagHandler();
   se->registerSubsystem(flag);

--- a/sPHENIX/CaloProduction/Fun4All_Year2.C
+++ b/sPHENIX/CaloProduction/Fun4All_Year2.C
@@ -20,7 +20,6 @@
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <ffamodules/HeadReco.h>
-#include <ffamodules/SyncReco.h>
 
 #include <fun4allraw/Fun4AllPrdfInputManager.h>
 

--- a/sPHENIX/TrackingProduction/Fun4All_Job0.C
+++ b/sPHENIX/TrackingProduction/Fun4All_Job0.C
@@ -7,7 +7,6 @@
 #include <Trkr_Clustering.C>
 #include <Trkr_RecoInit.C>
 
-#include <ffamodules/SyncReco.h>
 #include <fun4all/Fun4AllDstInputManager.h>
 #include <fun4all/Fun4AllDstOutputManager.h>
 #include <fun4all/Fun4AllInputManager.h>
@@ -57,8 +56,6 @@ void Fun4All_Job0(
   Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
   ingeo->AddFile(geofile);
   se->registerInputManager(ingeo);
-
-  se->registerSubsystem(new SyncReco);
 
   std::ifstream ifs(filelist);
   std::string filepath;

--- a/sPHENIX/TrackingProduction/Fun4All_JobA.C
+++ b/sPHENIX/TrackingProduction/Fun4All_JobA.C
@@ -13,7 +13,7 @@
 #include <fun4all/Fun4AllOutputManager.h>
 #include <fun4all/Fun4AllRunNodeInputManager.h>
 #include <fun4all/Fun4AllServer.h>
-#include <ffamodules/SyncReco.h>
+
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 
@@ -57,8 +57,6 @@ void Fun4All_JobA(
   Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
   ingeo->AddFile(geofile);
   se->registerInputManager(ingeo);
-
-  se->registerSubsystem(new SyncReco);
 
   std::ifstream ifs(filelist);
   std::string filepath;

--- a/sPHENIX/TrackingProduction/Fun4All_JobC.C
+++ b/sPHENIX/TrackingProduction/Fun4All_JobC.C
@@ -14,7 +14,6 @@
 #include <fun4all/Fun4AllRunNodeInputManager.h>
 #include <fun4all/Fun4AllServer.h>
 
-#include <ffamodules/SyncReco.h>
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 
@@ -60,8 +59,6 @@ void Fun4All_JobC(
   Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
   ingeo->AddFile(geofile);
   se->registerInputManager(ingeo);
-
-se->registerSubsystem(new SyncReco);
 
   std::ifstream ifs(filelist);
   std::string filepath;

--- a/sPHENIX/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
+++ b/sPHENIX/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
@@ -13,7 +13,6 @@
 #include <fun4all/Fun4AllRunNodeInputManager.h>
 #include <fun4all/Fun4AllServer.h>
 
-#include <ffamodules/SyncReco.h>
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 
@@ -56,8 +55,6 @@ void Fun4All_TrkrHitSet_Unpacker(
   Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
   ingeo->AddFile(geofile);
   se->registerInputManager(ingeo);
-
-  se->registerSubsystem(new SyncReco);
 
   std::ifstream ifs(filelist);
   std::string filepath;


### PR DESCRIPTION
The sync reco is run during the event combining. Running it again destroys the sync object which then prevents reading calos and track together