### PR TITLE
adjust bco ranges of mvtx, tpc and tpot

### DIFF
--- a/sPHENIX/cosmics/Fun4All_Stream_Combiner.C
+++ b/sPHENIX/cosmics/Fun4All_Stream_Combiner.C
@@ -171,8 +171,8 @@ void Fun4All_Stream_Combiner(int nEvents = 100,
     {
     SingleMvtxPoolInput *mvtx_sngl = new SingleMvtxPoolInput("MVTX_" + to_string(i));
     //    mvtx_sngl->Verbosity(3);
-    mvtx_sngl->SetBcoRange(1000);
-    mvtx_sngl->SetNegativeBco(1000);
+    mvtx_sngl->SetBcoRange(100);
+    mvtx_sngl->SetNegativeBco(100);
     mvtx_sngl->AddListFile(iter);
     in->registerStreamingInput(mvtx_sngl, InputManagerType::MVTX);
     i++;
@@ -186,7 +186,7 @@ void Fun4All_Stream_Combiner(int nEvents = 100,
     SingleTpcPoolInput *tpc_sngl = new SingleTpcPoolInput("TPC_" + to_string(i));
 //    tpc_sngl->Verbosity(2);
     //   tpc_sngl->DryRun();
-    tpc_sngl->SetBcoRange(130);
+    tpc_sngl->SetBcoRange(5);
     tpc_sngl->AddListFile(iter);
     in->registerStreamingInput(tpc_sngl, InputManagerType::TPC);
     i++;
@@ -200,7 +200,7 @@ void Fun4All_Stream_Combiner(int nEvents = 100,
     {
     SingleMicromegasPoolInput *mm_sngl = new SingleMicromegasPoolInput("MICROMEGAS_" + to_string(i));
     //   sngl->Verbosity(3);
-    mm_sngl->SetBcoRange(100);
+    mm_sngl->SetBcoRange(5);
     mm_sngl->SetNegativeBco(2);
     mm_sngl->AddListFile(iter);
     in->registerStreamingInput(mm_sngl, InputManagerType::MICROMEGAS);


### PR DESCRIPTION
At todays shift change meeting we decided to change the bco ranges for the streaming event combiner (100 for the mvtx, 5 for the tpc and tpot). Let's see how this goes