### PR TITLE
fix: add new node needed for seeding

### DIFF
--- a/sPHENIX/TrackingProduction/Fun4All_Job0.C
+++ b/sPHENIX/TrackingProduction/Fun4All_Job0.C
@@ -101,6 +101,7 @@ void Fun4All_Job0(
   out->AddNode("Sync");
   out->AddNode("EventHeader");
   out->AddNode("TRKR_CLUSTER");
+  out->AddNode("TRKR_CLUSTERCROSSINGASSOC");
   se->registerOutputManager(out);
 
   se->run(nEvents);


### PR DESCRIPTION
Silicon seeding now needs the cluster crossing association, this should be in the cluster DST.