### PR TITLE
enable syncing for trigger combiner

### DIFF
--- a/sPHENIX/triggers/Fun4All_Prdf_Combiner.C
+++ b/sPHENIX/triggers/Fun4All_Prdf_Combiner.C
@@ -84,6 +84,10 @@ void Fun4All_Prdf_Combiner(int nEvents = 0,
   Fun4AllServer *se = Fun4AllServer::instance();
   se->Verbosity(0);
   Fun4AllPrdfInputTriggerManager *in = new Fun4AllPrdfInputTriggerManager("Comb");
+  in->InitialPoolDepth(10);
+  in->SetPoolDepth(3);
+  in->Resync(true);
+
   //  in->Verbosity(1);
   // this one is the reference
   ifstream infile(gl1input);


### PR DESCRIPTION
Three line change to resync skipped events at the beginning of a run