### PR TITLE
use correct timestamp for cdb (runnumber right now)

### DIFF
--- a/sPHENIX/TrackingProduction/Fun4All_Job0.C
+++ b/sPHENIX/TrackingProduction/Fun4All_Job0.C
@@ -51,10 +51,10 @@ void Fun4All_Job0(
   se->Verbosity(1);
   auto rc = recoConsts::instance();
   rc->set_IntFlag("RUNNUMBER", runnumber);
+  CDBInterface::instance()->Verbosity(1);
 
-  Enable::CDB = true;
   rc->set_StringFlag("CDB_GLOBALTAG", dbtag ); 
-  rc->set_uint64Flag("TIMESTAMP", CDB::timestamp);
+  rc->set_uint64Flag("TIMESTAMP", runnumber);
  
   FlagHandler *flag = new FlagHandler();
   se->registerSubsystem(flag);
@@ -106,6 +106,7 @@ void Fun4All_Job0(
 
   se->run(nEvents);
   se->End();
+  CDBInterface::instance()->Print();
   se->PrintTimer();
   
   TString qaname = "HIST_" + outfilename;

--- a/sPHENIX/TrackingProduction/Fun4All_JobA.C
+++ b/sPHENIX/TrackingProduction/Fun4All_JobA.C
@@ -51,10 +51,10 @@ void Fun4All_JobA(
   se->Verbosity(1);
   auto rc = recoConsts::instance();
   rc->set_IntFlag("RUNNUMBER", runnumber);
+  CDBInterface::instance()->Verbosity(1);
 
-  Enable::CDB = true;
   rc->set_StringFlag("CDB_GLOBALTAG", dbtag ); 
-  rc->set_uint64Flag("TIMESTAMP", CDB::timestamp);
+  rc->set_uint64Flag("TIMESTAMP", runnumber);
 
   FlagHandler *flag = new FlagHandler();
   se->registerSubsystem(flag);
@@ -235,6 +235,7 @@ void Fun4All_JobA(
   std::string qaOutputFileName(qaname.Data());
   QAHistManagerDef::saveQARootFile(qaOutputFileName);
 
+  CDBInterface::instance()->Print();
 
   se->PrintTimer();
 

--- a/sPHENIX/TrackingProduction/Fun4All_JobC.C
+++ b/sPHENIX/TrackingProduction/Fun4All_JobC.C
@@ -45,10 +45,10 @@ void Fun4All_JobC(
   se->Verbosity(1);
   auto rc = recoConsts::instance();
   rc->set_IntFlag("RUNNUMBER", runnumber);
+  CDBInterface::instance()->Verbosity(1);
 
-  Enable::CDB = true;
   rc->set_StringFlag("CDB_GLOBALTAG", dbtag );
-  rc->set_uint64Flag("TIMESTAMP", CDB::timestamp);
+  rc->set_uint64Flag("TIMESTAMP", runnumber);
   
   FlagHandler *flag = new FlagHandler();
   se->registerSubsystem(flag);
@@ -123,6 +123,7 @@ out->AddNode("SvtxVertexMap");
 
   se->run(nEvents);
   se->End();
+  CDBInterface::instance()->Print();
   se->PrintTimer();
 
   delete se;

--- a/sPHENIX/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
+++ b/sPHENIX/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
@@ -47,10 +47,10 @@ void Fun4All_TrkrHitSet_Unpacker(
   se->Verbosity(1);
   auto rc = recoConsts::instance();
   rc->set_IntFlag("RUNNUMBER", runnumber);
+  CDBInterface::instance()->Verbosity(1);
 
-  Enable::CDB = true;
   rc->set_StringFlag("CDB_GLOBALTAG", dbtag );
-  rc->set_uint64Flag("TIMESTAMP", CDB::timestamp);
+  rc->set_uint64Flag("TIMESTAMP", runnumber);
 
   FlagHandler *flag = new FlagHandler();
   se->registerSubsystem(flag);
@@ -98,6 +98,7 @@ void Fun4All_TrkrHitSet_Unpacker(
   std::string qaOutputFileName(qaname.Data());
   QAHistManagerDef::saveQARootFile(qaOutputFileName);
 
+  CDBInterface::instance()->Print();
   se->PrintTimer();
 
   delete se;


### PR DESCRIPTION
The tracking macros use the wrong timestamp (6 instead of the current runnumber). This has mostly no effect right now since almost all our calibration go from 0 to infinity but this will change. The macros also now print the parameters which are used to extract a calibration and a printout at the end which files were used