### PR TITLE
fix: read runno from first file in filelist

### DIFF
--- a/sPHENIX/TrackingProduction/Fun4All_JobA.C
+++ b/sPHENIX/TrackingProduction/Fun4All_JobA.C
@@ -9,6 +9,8 @@
 #include <Trkr_Clustering.C>
 #include <Trkr_RecoInit.C>
 #include <Trkr_Reco.C>
+
+#include <fun4all/Fun4AllUtils.h>
 #include <fun4all/Fun4AllDstInputManager.h>
 #include <fun4all/Fun4AllDstOutputManager.h>
 #include <fun4all/Fun4AllInputManager.h>
@@ -43,38 +45,40 @@ void Fun4All_JobA(
 {
 
   gSystem->Load("libg4dst.so");
-  //char filename[500];
-  //sprintf(filename, "%s%08d-0000.root", inputRawHitFile.c_str(), runnumber);
- 
 
   auto se = Fun4AllServer::instance();
   se->Verbosity(1);
   auto rc = recoConsts::instance();
-  rc->set_IntFlag("RUNNUMBER", runnumber);
   CDBInterface::instance()->Verbosity(1);
 
   rc->set_StringFlag("CDB_GLOBALTAG", dbtag ); 
-  rc->set_uint64Flag("TIMESTAMP", runnumber);
 
   FlagHandler *flag = new FlagHandler();
   se->registerSubsystem(flag);
-
-  std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
-  Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
-  ingeo->AddFile(geofile);
-  se->registerInputManager(ingeo);
 
   std::ifstream ifs(filelist);
   std::string filepath;
   int i = 0;
   while(std::getline(ifs,filepath))
     {
+      if(i==0)
+	{
+	   std::pair<int, int> runseg = Fun4AllUtils::GetRunSegment(filepath);
+	   int runNumber = runseg.first;
+	   int segment = runseg.second;
+	   rc->set_IntFlag("RUNNUMBER", runNumber);
+	   rc->set_uint64Flag("TIMESTAMP", runNumber);
+	}
       std::string inputname = "InputManager" + std::to_string(i);
       auto hitsin = new Fun4AllDstInputManager(inputname);
       hitsin->fileopen(filepath);
       se->registerInputManager(hitsin);
       i++;
     }
+  std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
+  Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
+  ingeo->AddFile(geofile);
+  se->registerInputManager(ingeo);
 
   TrackingInit();
 

--- a/sPHENIX/TrackingProduction/Fun4All_JobC.C
+++ b/sPHENIX/TrackingProduction/Fun4All_JobC.C
@@ -7,6 +7,8 @@
 #include <Trkr_Clustering.C>
 #include <Trkr_RecoInit.C>
 #include <Trkr_Reco.C>
+
+#include <fun4all/Fun4AllUtils.h>
 #include <fun4all/Fun4AllDstInputManager.h>
 #include <fun4all/Fun4AllDstOutputManager.h>
 #include <fun4all/Fun4AllInputManager.h>
@@ -35,42 +37,44 @@ void Fun4All_JobC(
     const std::string dbtag = "2024p001",
     const std::string filelist = "filelist.list")
 {
-
   gSystem->Load("libg4dst.so");
-  //char filename[500];
-  //sprintf(filename, "%s%08d-0000.root", inputRawHitFile.c_str(), runnumber);
- 
 
   auto se = Fun4AllServer::instance();
   se->Verbosity(1);
   auto rc = recoConsts::instance();
-  rc->set_IntFlag("RUNNUMBER", runnumber);
   CDBInterface::instance()->Verbosity(1);
 
   rc->set_StringFlag("CDB_GLOBALTAG", dbtag );
-  rc->set_uint64Flag("TIMESTAMP", runnumber);
   
   FlagHandler *flag = new FlagHandler();
   se->registerSubsystem(flag);
   
   G4TRACKING::convert_seeds_to_svtxtracks = false;
 
-  std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
-  Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
-  ingeo->AddFile(geofile);
-  se->registerInputManager(ingeo);
-
   std::ifstream ifs(filelist);
   std::string filepath;
   int i = 0;
   while(std::getline(ifs,filepath))
     {
+      if(i==0)
+	{
+	   std::pair<int, int> runseg = Fun4AllUtils::GetRunSegment(filepath);
+	   int runNumber = runseg.first;
+	   int segment = runseg.second;
+	   rc->set_IntFlag("RUNNUMBER", runNumber);
+	   rc->set_uint64Flag("TIMESTAMP", runNumber);
+	}
       std::string inputname = "InputManager" + std::to_string(i);
       auto hitsin = new Fun4AllDstInputManager(inputname);
       hitsin->fileopen(filepath);
       se->registerInputManager(hitsin);
       i++;
     }
+
+  std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
+  Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
+  ingeo->AddFile(geofile);
+  se->registerInputManager(ingeo);
 
   TrackingInit();
 

--- a/sPHENIX/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
+++ b/sPHENIX/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
@@ -7,6 +7,7 @@
 #include <GlobalVariables.C>
 #include <Trkr_Clustering.C>
 
+#include <fun4all/Fun4AllUtils.h>
 #include <fun4all/Fun4AllDstInputManager.h>
 #include <fun4all/Fun4AllDstOutputManager.h>
 #include <fun4all/Fun4AllInputManager.h>
@@ -39,38 +40,41 @@ void Fun4All_TrkrHitSet_Unpacker(
 {
 
   gSystem->Load("libg4dst.so");
-  //char filename[500];
-  //sprintf(filename, "%s%08d-0000.root", inputRawHitFile.c_str(), runnumber);
- 
-
+  
   auto se = Fun4AllServer::instance();
   se->Verbosity(1);
   auto rc = recoConsts::instance();
-  rc->set_IntFlag("RUNNUMBER", runnumber);
+ 
   CDBInterface::instance()->Verbosity(1);
-
   rc->set_StringFlag("CDB_GLOBALTAG", dbtag );
-  rc->set_uint64Flag("TIMESTAMP", runnumber);
 
   FlagHandler *flag = new FlagHandler();
   se->registerSubsystem(flag);
-
-  std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
-  Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
-  ingeo->AddFile(geofile);
-  se->registerInputManager(ingeo);
 
   std::ifstream ifs(filelist);
   std::string filepath;
   int i = 0;
   while(std::getline(ifs,filepath))
     {
+      if(i==0)
+	{
+	   std::pair<int, int> runseg = Fun4AllUtils::GetRunSegment(filepath);
+	   int runNumber = runseg.first;
+	   int segment = runseg.second;
+	   rc->set_IntFlag("RUNNUMBER", runNumber);
+	   rc->set_uint64Flag("TIMESTAMP", runNumber);
+	}
       std::string inputname = "InputManager" + std::to_string(i);
       auto hitsin = new Fun4AllDstInputManager(inputname);
       hitsin->fileopen(filepath);
       se->registerInputManager(hitsin);
       i++;
     }
+
+  std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
+  Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
+  ingeo->AddFile(geofile);
+  se->registerInputManager(ingeo);
 
   Mvtx_HitUnpacking();
   Intt_HitUnpacking();


### PR DESCRIPTION
Reads the runnumber from the first file in the file list using the standard util. Tested on DSTs from a random run 48001. @pinkenburg can you confirm this matches the expected design