### PR TITLE
add missing Sync and EventHeader nodes to output

### DIFF
--- a/sPHENIX/TrackingProduction/Fun4All_JobC.C
+++ b/sPHENIX/TrackingProduction/Fun4All_JobC.C
@@ -121,8 +121,10 @@ void Fun4All_JobC(
   se->registerSubsystem(finder);
 
   Fun4AllOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", outfilename);
+  out->AddNode("Sync");
+  out->AddNode("EventHeader");
   out->AddNode("SvtxTrackMap");
-out->AddNode("SvtxVertexMap");
+  out->AddNode("SvtxVertexMap");
   se->registerOutputManager(out);
 
   se->run(nEvents);


### PR DESCRIPTION
The track dsts do not contain the sync object so they cannot be combined with any other DST. This PR adds the Sync and EventHeader node to the dst