### PR TITLE
Laser clustering

### DIFF
--- a/sPHENIX/TrackingProduction/Fun4All_Job0.C
+++ b/sPHENIX/TrackingProduction/Fun4All_Job0.C
@@ -5,6 +5,7 @@
  */
 #include <GlobalVariables.C>
 #include <Trkr_Clustering.C>
+#include <Trkr_LaserClustering.C>
 #include <Trkr_RecoInit.C>
 #include <QA.C>
 

--- a/sPHENIX/TrackingProduction/Fun4All_Job0.C
+++ b/sPHENIX/TrackingProduction/Fun4All_Job0.C
@@ -93,6 +93,8 @@ void Fun4All_Job0(
   tpcclusterizer->set_rawdata_reco();
   se->registerSubsystem(tpcclusterizer);
 
+  TPC_LaserClustering();
+
   Micromegas_Clustering();
 
   se->registerSubsystem(new MvtxClusterQA);
@@ -107,6 +109,10 @@ void Fun4All_Job0(
   out->AddNode("EventHeader");
   out->AddNode("TRKR_CLUSTER");
   out->AddNode("TRKR_CLUSTERCROSSINGASSOC");
+  if(G4TPC::ENABLE_CENTRAL_MEMBRANE_HITS)
+  {
+    out->AddNode("LASER_CLUSTER");
+  }
   se->registerOutputManager(out);
 
   se->run(nEvents);


### PR DESCRIPTION
Added laser clustering to job 0. Will only run if G4TPC::ENABLE_CENTRAL_MEMBRANE_HITS == true (which has been set to default in macros with https://github.com/sPHENIX-Collaboration/macros/pull/913