### PR TITLE
Dbinputs

### DIFF
--- a/sPHENIX/RAMENYA_LOOP_PHYSICS_2024.yaml
+++ b/sPHENIX/RAMENYA_LOOP_PHYSICS_2024.yaml
@@ -15,7 +15,6 @@ PHYS_DST_STREAMING_EVENT_run2pp:
      neventsper: 1000
      comment :    "---"
      rsync   : "./slurp-examples/sPHENIX/cosmics/*,cups.py,bachi.py,odbc.ini"
-
    input:
       db: daqdb
       direct_path: /sphenix/lustre01/sphnxpro/{mode}/*/physics/
@@ -26,6 +25,7 @@ PHYS_DST_STREAMING_EVENT_run2pp:
                 0                                                                                                   as segment     , 
                 string_agg( distinct split_part(filename,'/',-1), ' ' )                                             as files       ,   
                 string_agg( distinct split_part(filename,'/',-1) || ':' || firstevent || ':' || lastevent, ' ' )    as fileranges  
+
          from filelist
          where 
            ( 

--- a/sPHENIX/cosmics/run_cosmics.sh
+++ b/sPHENIX/cosmics/run_cosmics.sh
@@ -163,7 +163,6 @@ cat inputfiles.list | while read -r f; do
     
 done
 
-./cups.py -r ${runnumber} -s ${segment} -d ${outbase} inputs --files ${inputlist}
 #______________________________________________________________________________________________
 
 touch gl1.list

--- a/sPHENIX/cosmics/run_cosmics.sh
+++ b/sPHENIX/cosmics/run_cosmics.sh
@@ -54,11 +54,9 @@ else
    done
 fi
 
-while read -r fname; do
-   echo $fname
-done < inputfiles.list
-
-
+#while read -r fname; do
+#   echo $fname
+#done < inputfiles.list
 
 #______________________________________________________________________________________________
 # Map TPC input files into filelists

--- a/sPHENIX/cosmics/run_cosmics.sh
+++ b/sPHENIX/cosmics/run_cosmics.sh
@@ -38,9 +38,6 @@ source /opt/sphenix/core/bin/sphenix_setup.sh -n ${5}
 
 export ODBCINI=./odbc.ini
 
-echo "INPUTS" 
-echo ${inputs[@]}
-
 echo "PAYLOAD"
 for i in ${payload[@]}; do
     cp --verbose ${subdir}/${i} .
@@ -48,11 +45,27 @@ done
 
 ./cups.py -r ${runnumber} -s ${segment} -d ${outbase} started
 
+echo "INPUTS" 
+if [[ "${9}" == *"dbinput"* ]]; then
+   ./cups.py -r ${runnumber} -s ${segment} -d ${outbase} getinputs >> inputfiles.list
+else
+   for i in ${inputs[@]}; do
+      echo $i >> inputfiles.list
+   done
+fi
+
+while read -r fname; do
+   echo $fname
+done < inputfiles.list
+
+
+
 #______________________________________________________________________________________________
 # Map TPC input files into filelists
 # TPC_ebdc23_cosmics-00030117-0009.evt test%%_cosmics*
 inputlist=""
-for f in "${inputs[@]}"; do
+#for f in "${inputs[@]}"; do
+cat inputfiles.list | while read -r f; do
     b=$( basename $f )
     # TPC files
     if [[ $b =~ "TPC_ebdc" ]]; then


### PR DESCRIPTION
File lists can become arbitrarily long, pushing the argument list to the production script beyond the limit supported by linux.  This works around the issue by using the DB to provide the file list.